### PR TITLE
Bootstrap 3 does not include typeahead

### DIFF
--- a/token-input-bootstrap3.css.scss
+++ b/token-input-bootstrap3.css.scss
@@ -68,7 +68,6 @@ li.token-input-input-token-bootstrap {
 
 div.token-input-dropdown-bootstrap {
   @extend .dropdown-menu;
-  @extend .typeahead;
 }
 
 div.token-input-dropdown-bootstrap p {


### PR DESCRIPTION
Since Bootstrap 3 does not include typeahead and the stylesheet references it, it raises an error.
